### PR TITLE
Removed unused traces of Plotly plotting Path Planners

### DIFF
--- a/src/path_planning/algorithms/cbs.py
+++ b/src/path_planning/algorithms/cbs.py
@@ -7,7 +7,6 @@ from queue import PriorityQueue
 from typing import Dict, List, NamedTuple, Optional, Tuple
 
 import numpy as np
-import plotly.graph_objects as go
 
 from .path_planner import Agent, AgentPaths, Goal, PathPlanner
 from ..omap import OMap
@@ -16,6 +15,7 @@ from ..utils import Path, Point
 Solution = Dict[Agent, Tuple[Path, float]]
 
 count = 0
+
 
 class Conflict(NamedTuple):
     """Conflict for CBS."""
@@ -99,6 +99,7 @@ class CBS(PathPlanner):
 
             path = np.vstack((np.append(start, cost_so_far[start_bytes]), path))
             return path[:-1]
+
         global count
         if existing_path is None:
             start_byte = (start.astype(np.float64)).tobytes()
@@ -167,7 +168,7 @@ class CBS(PathPlanner):
                     if path is not None:
                         return (np.vstack((path_pre_constriant, path)), path[-1])
                     break
-                
+
                 new_neighbors = get_neighbors_cells(
                     curr_time + 1, current_point, constraint
                 )
@@ -232,7 +233,7 @@ class CBS(PathPlanner):
         omap: OMap,
         goals: Dict[Agent, List[Goal]],
         override_starting_pos: None | Dict[Agent, Point] = None,
-    ) -> Tuple[AgentPaths, go.Figure]:  # pyright: ignore[reportGeneralTypeIssues]
+    ) -> AgentPaths:  # pyright: ignore[reportGeneralTypeIssues]
         """Conflict Base Search PathPlanner."""
         goals = {
             key: [
@@ -299,7 +300,7 @@ class CBS(PathPlanner):
                 agent_paths = {
                     k: v[0] * omap.cell_size for k, v in cur_node.solution.items()
                 }
-                return (agent_paths, go.Figure())
+                return agent_paths
             for agent in conflict.agent_set:
                 constraint = Constraint(agent, conflict.vertex, conflict.time)
                 # constraint_set = {constraint}  # + cur_node.constraints

--- a/src/path_planning/algorithms/path_planner.py
+++ b/src/path_planning/algorithms/path_planner.py
@@ -3,8 +3,6 @@
 from abc import ABC, abstractmethod
 from typing import Dict, List, Tuple
 
-import plotly.graph_objects as go
-
 from ..omap import OMap
 from ..utils import Agent, Goal, Path, Point
 
@@ -21,7 +19,7 @@ class PathPlanner(ABC):
         omap: OMap,
         goals: dict[Agent, List[Goal]],
         override_starting_pos: None | Dict[Agent, Point] = None,
-    ) -> Tuple[AgentPaths, go.Figure]:
+    ) -> AgentPaths:
         """Abstract Base Class for a PathPlanner."""
         pass
 
@@ -32,11 +30,6 @@ class AStar(PathPlanner):
     @staticmethod
     def generate(
         omap: OMap, goals: dict[str, list[Goal]]
-    ) -> Tuple[AgentPaths, go.Figure]:  # pyright:ignore
+    ) -> AgentPaths:  # pyright:ignore
         """Execute A* to generate a path."""
-        pass
-
-    @staticmethod
-    def build_figure() -> go.Figure:
-        """Build Astar plotly figure."""
         pass

--- a/src/path_planning/sandbox.py
+++ b/src/path_planning/sandbox.py
@@ -21,16 +21,18 @@ def main() -> None:
 
     test_omap.set_rectangles(np.array([3, 3, 0]), np.array([6, 6, 1.9]))
 
-    ag1 = Agent(name="CF 1", pos=np.array([1.05901491, 7.13232832, 0.5328699]))  # global starting position
+    ag1 = Agent(
+        name="CF 1", pos=np.array([1.05901491, 7.13232832, 0.5328699])
+    )  # global starting position
     ag2 = Agent(name="CF 2", pos=np.array([9.55325931, 6.58183465, 1.35118168]))
 
     # Goals in cells
     goals = {
         ag1: [Goal(np.array([1.78599858, 2.51949983, 0.13095248]))],
-        ag2: [Goal(np.array([2.99585621, 0.36188631, 0.2105532 ]))],
+        ag2: [Goal(np.array([2.99585621, 0.36188631, 0.2105532]))],
     }
 
-    agent_paths, _figure = CBS.generate(
+    agent_paths = CBS.generate(
         test_omap,
         goals,
     )

--- a/src/path_planning/sweeps.py
+++ b/src/path_planning/sweeps.py
@@ -1,4 +1,3 @@
-
 """Wrappers for testing algorithms."""
 
 import time
@@ -67,6 +66,5 @@ def sweep_cbs(iterations: int, num_agents: int, omap: OMap, min_path_length: flo
             goals,
         )
         end_time = time.process_time()
-        results.append((result[0], end_time - start_time))
+        results.append((result, end_time - start_time))
     return results
-


### PR DESCRIPTION
Path Planners seem to still have vestiges of Plotly plotting even though we seem to either not use it, or actively avoid using it (like in `sweeps.py`, where we just pick out the first part of the tuple). 

Since plotting has been moved elsewhere, maybe the core path planner classes can be purely algorithm?